### PR TITLE
Use RETURN instead of deprecated [Return]

### DIFF
--- a/resources/robot_magik_base.robot
+++ b/resources/robot_magik_base.robot
@@ -131,7 +131,7 @@ Open Magik Connection
     # cause the prio running "Test Magik Output" could not read the complete (expected)
     # traceback block.
     Set Prompt    \\s${out}    True
-    [Return]    ${out}
+    RETURN    ${out}
 
 Write Magik Command
     [Arguments]    ${magik_expression}
@@ -155,7 +155,7 @@ Read Magik Output
     Should Not Match Regexp    ${out_orig}    .*traceback:|.*\\(parser_error\\)
     Run Keyword If    '${error_regexp}'!=''    Should Not Match Regexp    ${out_orig}    ${error_regexp}
     ${match}    ${out}=    Should Match Regexp    ${out_orig}    ${MAGIK_PROMPT_REGEXP}
-    [Return]    ${out}
+    RETURN    ${out}
 
 Prepare Magik Image
     [Documentation]    Sends some initial Magik commands to prepare the test session.
@@ -190,7 +190,7 @@ Close Magik Connection
     ...
     ...    Returns any remaining output.
     ${out}=    Close Connection
-    [Return]    ${out}
+    RETURN    ${out}
 
 Execute Magik Command
     [Arguments]    ${magik_expression}    ${error_regexp}=
@@ -204,7 +204,7 @@ Execute Magik Command
     ${count}=    Get Length    ${out}
     ${last_line}=    Run Keyword If    ${count}!=0    Get Line    ${out}    -1
     ${result}=    Run Keyword If    ${count}!=0    Remove String Using Regexp    ${last_line}    \\s*$
-    [Return]    ${result}
+    RETURN    ${result}
 
 Build Magik Object Expression
     [Arguments]    ${obj_name}
@@ -214,7 +214,7 @@ Build Magik Object Expression
     ...
     ...    see although `Store Magik Object` and `Get Magik Object`
     ${obj_expression}=    Convert To String    ${CLI_OBJ_HASH}\[:${obj_name}]
-    [Return]    ${obj_expression}
+    RETURN    ${obj_expression}
 
 Store Magik Object
     [Arguments]    ${obj_name}    ${magik_expression}
@@ -225,7 +225,7 @@ Store Magik Object
     ...    see although `Build Magik Object Expression`, \ `Get Magik Object` and `Prepare Magik Image`
     ${obj_expression}=    Build Magik Object Expression    ${obj_name}
     Execute Magik Command    ${obj_expression} << ${magik_expression}
-    [Return]    ${obj_expression}
+    RETURN    ${obj_expression}
 
 Get Magik Object
     [Arguments]    ${obj_name}
@@ -237,7 +237,7 @@ Get Magik Object
     ...    see although `Store Magik Object` and \ `Prepare Magik Image`
     ${obj_expression}=    Build Magik Object Expression    ${obj_name}
     ${out}=    Execute Magik Command    ${obj_expression}
-    [Return]    ${out}
+    RETURN    ${out}
 
 Get Magik Environment Variable
     [Arguments]    ${env_name}
@@ -245,7 +245,7 @@ Get Magik Environment Variable
     ...
     ...    It's the value, as it is known inside the Magik Image
     ${out}=    Execute Magik Command    system.getenv("${env_name}")
-    [Return]    ${out}
+    RETURN    ${out}
 
 Load Magik File
     [Arguments]    ${magik_file}    ${max_load_wait}=${MAGIK_MAX_LOAD_WAIT}    ${error_regexp}=${MAGIK_LOAD_ERROR_REGEXP}
@@ -263,7 +263,7 @@ Load Magik File
     Write Magik Command    load_file("${magik_file}")
     ${out}=    Read Magik Output    ${error_regexp}
     [Teardown]    Set Timeout    ${CLI_TIMEOUT}
-    [Return]    ${out}
+    RETURN    ${out}
 
 Load Magik Module
     [Arguments]    ${module_name}    ${module_version}=_unset    ${max_load_wait}=${MAGIK_MAX_LOAD_WAIT}    ${error_regexp}=${MAGIK_LOAD_ERROR_REGEXP}
@@ -300,7 +300,7 @@ Load Magik Module
     Write Magik Command    sw_module_manager.load_module( :${module_name}, ${module_version}, ${opt_magikc}, ${opt_reload}, ${opt_update} )
     ${out}=    Read Magik Output    ${error_regexp}
     [Teardown]    Set Timeout    ${CLI_TIMEOUT}
-    [Return]    ${out}
+    RETURN    ${out}
 
 Get Smallworld Version
     [Documentation]    Returns Magik Image Smallworld Version as string
@@ -308,4 +308,4 @@ Get Smallworld Version
     ...    - sw41 returns xxx
     ${out}=    Execute Magik Command    write(smallworld_product.sw!version.write_string)
     ${swv}=    Remove String    ${out}    .
-    [Return]    ${swv}
+    RETURN    ${swv}

--- a/resources/robot_magik_dsview.robot
+++ b/resources/robot_magik_dsview.robot
@@ -40,7 +40,7 @@ Get DsView
     ${objkey}    Set Variable If    '${objkey}'=='default'    ${dsview_name}    ${objkey}
     ${command}    Set Variable If    '${dsview_name}' in ('ace', 'style', 'authorisation')     ${dsview_name}_view    cached_dataset(:${dsview_name})
     ${dsview_expr}=    Store Magik Object    ${objkey}    gis_program_manager.${command}
-    [Return]    ${dsview_expr}
+    RETURN    ${dsview_expr}
 
 Rollback DsView
     [Arguments]    ${dsview_name}=${CLI_DSVIEW_NAME}
@@ -65,7 +65,7 @@ Get DsCollection
     ${objkey}    Set Variable If    '${objkey}'=='default'    ${dscoll_name}    ${objkey}
     ${dsview_expr}=    Build Magik Object Expression    ${dsview_name}
     ${dscoll_expr}=    Store Magik Object    ${objkey}    ${dsview_expr}.collections[:${dscoll_name}]
-    [Return]    ${dscoll_expr}
+    RETURN    ${dscoll_expr}
 
 Get SelectCollection
     [Arguments]    ${coll_name}    ${predicate}    ${objkey}=default
@@ -81,7 +81,7 @@ Get SelectCollection
     ${objkey}    Set Variable If    '${objkey}'=='default'    ${coll_name}_s    ${objkey}
     ${coll_expr}=    Build Magik Object Expression    ${coll_name}
     ${coll_expr_s}=    Store Magik Object    ${objkey}    ${coll_expr}.select(${predicate})
-    [Return]    ${coll_expr_s}
+    RETURN    ${coll_expr_s}
 
 Get Record
     [Arguments]    ${coll_name}    ${objkey}=a_rec
@@ -98,7 +98,7 @@ Get Record
     ...    so that it is stored (known) inside the global ${CLI_OBJ_HASH}
     ${coll_expr}=    Build Magik Object Expression    ${coll_name}
     ${rec_expr}=    Store Magik Object    ${objkey}    ${coll_expr}.an_element()
-    [Return]    ${rec_expr}
+    RETURN    ${rec_expr}
 
 Get Record With Predicate
     [Arguments]    ${coll_name}    ${predicate}    ${objkey}=a_pred_rec
@@ -117,7 +117,7 @@ Get Record With Predicate
     ...    so that it is stored (known) inside the global ${CLI_OBJ_HASH}
     ${coll_expr}=    Get SelectCollection    ${coll_name}    ${predicate}
     ${rec_expr}=    Store Magik Object    ${objkey}    ${coll_expr}.an_element()
-    [Return]    ${rec_expr}
+    RETURN    ${rec_expr}
 
 Report Datamodel History
     [Arguments]    ${dsview_name}=${CLI_DSVIEW_NAME}    ${fname}=datamodel_history_${dsview_name}.txt    ${report_dir}=${OUTPUT DIR}
@@ -131,7 +131,7 @@ Report Datamodel History
     ${out1}=    Read Magik Output
     ${checkpoint_list}=    Remove String Using Regexp    ${out1}    \\S+:\\d+:(MagikSF|Magik)>
     Create File    ${report_fname_full}    ${header_info}${checkpoint_list}
-    [Return]    ${report_fname_full}
+    RETURN    ${report_fname_full}
 
 Get Datamodel History Entry
     [Arguments]    ${product}    ${model}    ${sub_model}    ${dsview_name}=${CLI_DSVIEW_NAME}
@@ -148,7 +148,7 @@ Get Datamodel History Entry
     Get DsView    ${dsview_name}
     Get DsCollection    sw_gis!datamodel_history    ${dsview_name}    ${histo_key}
     ${rec_expr}=    Get Record With Predicate    ${histo_key}    ${histo_pred}    ${histo_key}_rec
-    [Return]    ${rec_expr}
+    RETURN    ${rec_expr}
 
 Datamodel History Entry Should Exist
     [Arguments]    ${product}    ${model}    ${sub_model}    ${dsview_name}=${CLI_DSVIEW_NAME}
@@ -163,4 +163,4 @@ Datamodel History Entry Should Exist
     ${histo_rec_expr}=    Get Datamodel History Entry    ${product}     ${model}    ${sub_model}     ${dsview_name}
     ${output}=    Execute Magik Command    ${histo_rec_expr}
     Should Match    ${output}    sw_gis!datamodel_history*${model}*${sub_model})    History record not found in <${dsview_name}>: ${product} - ${model} - ${sub_model}    values=${False}
-    [Return]    ${output}
+    RETURN    ${output}

--- a/resources/robot_magik_munit.robot
+++ b/resources/robot_magik_munit.robot
@@ -72,7 +72,7 @@ Prepare MUnit
     ...    if ${munit_dir} is defined, environment variable ``ROBOT_MUNIT_DIR`` is set, before loading ${munit_load_file}
     Run Keyword If    '${munit_dir}' != ''    Execute Magik Command    system.putenv("ROBOT_MUNIT_DIR", "${munit_dir}")
     ${out}=    Load Magik File    ${munit_load_file}    max_load_wait=${ROBOT_MUNIT_MAX_LOAD_WAIT}
-    [Return]    ${out}
+    RETURN    ${out}
 
 Load Module with MUnit Tests and Start Test Runner
     [Arguments]    ${module_with_tests}    ${log_extension}=log    ${log_dir}=${ROBOT_MUNIT_LOG_DIR}
@@ -86,7 +86,7 @@ Load Module with MUnit Tests and Start Test Runner
     ${testsuite_name}=    Set Variable    ${module_with_tests}_${swv}
     Store Magik Object    ${testsuite_name}    test_suite.new_from_module(:${module_with_tests} )
     ${munit_log_content}=    Run MUnit Testsuite Logging to File    ${testsuite_name}    ${log_extension}    ${log_dir}
-    [Return]    ${munit_log_content}
+    RETURN    ${munit_log_content}
 
 Run MUnit Testsuite Logging to File
     [Arguments]    ${testsuite_name}    ${log_extension}=log    ${log_dir}=${ROBOT_MUNIT_LOG_DIR}    ${max_run_wait}=${ROBOT_MUNIT_MAX_RUN_WAIT}
@@ -119,7 +119,7 @@ Run MUnit Testsuite Logging to File
     ${munit_log_fname}=    Get MUnit Log File Name from Test Runner Output    ${out}    ${testsuite_name}
     ${munit_log_content}=    Get File    ${munit_log_fname}
     [Teardown]    Set Timeout    ${CLI_TIMEOUT}
-    [Return]    ${munit_log_content}
+    RETURN    ${munit_log_content}
 
 Get MUnit Log File Name from Test Runner Output
     [Arguments]    ${trunner_output}    ${testsuite_name}
@@ -151,7 +151,7 @@ Get MUnit Log File Name from Test Runner Output
     ${log_fname_parts}=    Split Extension    ${log_path_parts}[1]
     ${log_ex_name}=    Set Variable If    'xml' in '${log_fname_parts}[1]'    MUnit xml log    MUnit text log
     Set Test Variable    ${CURRENT_MUNIT_LOG_LINK}    <a href="./${log_path_parts}[1]">${log_ex_name}</a>
-    [Return]    ${munit_log_fname}
+    RETURN    ${munit_log_fname}
 
 Evaluate MUnit Text Log
     [Arguments]    ${munit_text_log}    ${expected_failures}=0    ${expected_errors}=0    ${testsuite_name}=

--- a/resources/robot_magik_session.robot
+++ b/resources/robot_magik_session.robot
@@ -36,7 +36,7 @@ Auto Start Magik Session
     Run Keyword And Return If    ${AUTO_START_MAGIK_SESSION} == ${False}    Log To Console    Starting Magik Session was disabled by AUTO_START_MAGIK_SESSION
     ${msession}=    Start Magik Session    @{args}    &{further_key_value_pairs}
     Session Should Be Reachable    ${msession.cli_port}
-    [Return]    ${msession}
+    RETURN    ${msession}
 
 Auto Stop Magik Session
     [Arguments]    ${cli_port}=${None}    ${kill}=${True}
@@ -47,4 +47,4 @@ Auto Stop Magik Session
     ...    Returns [http://robotframework.org/robotframework/latest/libraries/Process.html#Result%20object|Process result object]
     Run Keyword And Return If    ${AUTO_STOP_MAGIK_SESSION} == ${False}    Log To Console    Stopping Magik Session was disabled by AUTO_STOP_MAGIK_SESSION
     ${result}=    Stop Magik Session    ${cli_port}    ${kill}
-    [Return]    ${result}
+    RETURN    ${result}


### PR DESCRIPTION
Use `RETURN` instead of deprecated `[Return]`. In Robot Framework 5.0 the `RETURN` statement was introduced to overcome limitations of `[Return]`. See https://github.com/robotframework/robotframework/blob/master/doc/releasenotes/rf-5.0.rst#return.

Currently Robot Framework (7.2) shows a warning when `[Return]` is used:
```
[ WARN ] Error in file '...\resources\robot_magik_base.robot' on line 134: The '[Return]' setting is deprecated. Use the 'RETURN' statement instead.
```

This PR changes the use of `[Return]` to `RETURN`, removing this warning.